### PR TITLE
[RFR] Improve Sedy's response to the world

### DIFF
--- a/src/commiter.js
+++ b/src/commiter.js
@@ -1,4 +1,4 @@
-export default (config, githubApi, git) => {
+export default (logger, githubApi, git) => {
     const digestCommit = function* (parsedContent, fix) {
         yield git.checkout(parsedContent.pullRequest.ref);
 
@@ -10,10 +10,9 @@ export default (config, githubApi, git) => {
 
         yield git.add(newBlob, '/' + parsedContent.comment.path);
 
-        const message = `Typo fix authored by ${parsedContent.comment.sender}
+        const message = `Typo fix s/${fix.match.from}/${fix.match.to}/
 
-${git.commitAuthor.name} is configured to automatically commit change authored by specific syntax in a comment.
-See the trigger at ${parsedContent.comment.url}`;
+As requested by @${parsedContent.comment.sender} at ${parsedContent.comment.url}`;
 
         const commit = yield git.commit(parsedContent.pullRequest.ref, message);
 
@@ -46,8 +45,7 @@ See the trigger at ${parsedContent.comment.url}`;
                 commits.push(commit);
             }
 
-            yield replyToAuthor(parsedContent, `:white_check_mark: @${parsedContent.comment.sender}, check out my commits!
-I have fixed your typo(s) at ${commits.map(commit => commit.sha).join(', ')}`);
+            logger.info('Successful commits', { commitsIds: commits.map(commit => commit.sha) });
 
             return true;
         } catch (error) {

--- a/src/fixer.js
+++ b/src/fixer.js
@@ -44,6 +44,7 @@ export default git => {
         return {
             blob,
             content: newBlobContent,
+            match,
         };
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,15 +40,13 @@ const main = function* (event, context) {
     const fixedContent = yield fixer.fixTypo(parsedContent);
     logger.debug('Content fixed', { fixedContent });
 
-    const commiter = commiterFactory(config, githubClient, git);
+    const commiter = commiterFactory(logger, githubClient, git);
     const success = yield commiter.commit(parsedContent, fixedContent);
 
-    const response = {
+    return {
         success,
         result: parsedContent.matches,
     };
-
-    return response;
 };
 
 export const handler = function (event, context, callback) {
@@ -63,6 +61,10 @@ export const handler = function (event, context, callback) {
             message: error.message,
             stack: error.stack,
         });
-        callback(new Error('An error occured, please contact an administrator.'));
+
+        callback(null, {
+            success: false,
+            error: 'An error occured, please contact an administrator.',
+        });
     });
 };


### PR DESCRIPTION
- Do not reply to PR comment if it succeed (fix #31)
- Log the commits ids instead
- Hide potentials errors to users