### PR TITLE
[RFR] Fix ping parser response

### DIFF
--- a/sedy/src/parser/index.js
+++ b/sedy/src/parser/index.js
@@ -1,9 +1,13 @@
 import getGitHubEventHeader from './getGitHubEventHeader';
 import parsePullRequestReviewFactory from './parsePullRequestReview';
 
+const pingParser = () => () => function* () {
+    return [];
+};
+
 export default (client, logger) => {
     const parsers = {
-        ping: () => null,
+        ping: pingParser,
         pull_request_review: parsePullRequestReviewFactory,
     };
 


### PR DESCRIPTION
We've got a lot of TypeError `parser(...) is not a function`
It's due to the number of Sedy installation from Hacker News.

This commit aims to fix the response to the GitHub `ping` event.