### PR TITLE
[RFR] Support GitHub App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ sedy/build/*
 sedy/config/development.json
 sedy/config/production.json
 sedy/config/test.json
+sedy/config/private-key.pem
 
 # Sedy Installer
 installer/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ sedy/build/*
 sedy/config/development.json
 sedy/config/production.json
 sedy/config/test.json
-sedy/config/private-key.pem
+sedy/config/privateKeys/*.pem
 
 # Sedy Installer
 installer/node_modules/

--- a/sedy/config/default.json
+++ b/sedy/config/default.json
@@ -1,7 +1,8 @@
 {
     "bot": {
         "login": "GITHUB-ACCOUNT",
-        "oauthToken": "GITHUB-OAUTH-ACCESS-TOKEN"
+        "oauthToken": "GITHUB-OAUTH-ACCESS-TOKEN",
+        "integrationId": "GITHUB-INTEGRATION-ID"
     },
     "committer": {
         "name": "COMMITTER-NAME",

--- a/sedy/config/default.json
+++ b/sedy/config/default.json
@@ -2,7 +2,7 @@
     "bot": {
         "login": "GITHUB-ACCOUNT",
         "oauthToken": "GITHUB-OAUTH-ACCESS-TOKEN",
-        "integrationId": "GITHUB-INTEGRATION-ID"
+        "appId": "GITHUB-APP-ID"
     },
     "committer": {
         "name": "COMMITTER-NAME",

--- a/sedy/config/production-dist.json
+++ b/sedy/config/production-dist.json
@@ -1,7 +1,8 @@
 {
     "bot": {
         "login": "sedy-bot",
-        "oauthToken": ""
+        "oauthToken": "",
+        "appId": 0
     },
     "committer": {
         "name": "sedy-bot",

--- a/sedy/githubAppPrivateKey.js
+++ b/sedy/githubAppPrivateKey.js
@@ -1,0 +1,5 @@
+import fs from 'fs';
+
+const env = process.env.NODE_ENV || 'development';
+
+module.exports = fs.readFileSync(`${__dirname}/config/privateKeys/${env}.pem`);

--- a/sedy/githubAppPrivateKey.js
+++ b/sedy/githubAppPrivateKey.js
@@ -2,4 +2,6 @@ import fs from 'fs';
 
 const env = process.env.NODE_ENV || 'development';
 
-module.exports = fs.readFileSync(`${__dirname}/config/privateKeys/${env}.pem`);
+const buffer = fs.readFileSync(`${__dirname}/config/privateKeys/${env}.pem`);
+
+module.exports = JSON.stringify(buffer.toString('utf-8'));

--- a/sedy/githubIntegrationPrivateKey.js
+++ b/sedy/githubIntegrationPrivateKey.js
@@ -1,3 +1,0 @@
-import fs from 'fs';
-
-module.exports = fs.readFileSync(`${__dirname}/config/private-key.pem`);

--- a/sedy/githubIntegrationPrivateKey.js
+++ b/sedy/githubIntegrationPrivateKey.js
@@ -1,0 +1,3 @@
+import fs from 'fs';
+
+module.exports = fs.readFileSync(`${__dirname}/config/private-key.pem`);

--- a/sedy/makefile
+++ b/sedy/makefile
@@ -10,7 +10,7 @@ clean:
 	rm -rf build/*
 
 build: clean
-	./node_modules/.bin/webpack --progress
+	./node_modules/.bin/webpack --progress -p
 
 run:
 	./node_modules/.bin/nodemon \

--- a/sedy/package.json
+++ b/sedy/package.json
@@ -16,8 +16,10 @@
     "config": "~1.20.1",
     "escape-string-regexp": "~1.0.5",
     "github": "~0.2.4",
+    "jsonwebtoken": "^7.3.0",
     "oauth": "~0.9.14",
-    "octonode": "~0.7.5"
+    "octonode": "~0.7.5",
+    "request": "^2.80.0"
   },
   "devDependencies": {
     "babel-core": "~6.7.7",
@@ -33,7 +35,6 @@
     "json-loader": "~0.5.4",
     "mocha": "~2.4.5",
     "nodemon": "~1.11.0",
-    "request": "2.76.0",
     "sinon": "~1.17.3",
     "webpack": "~2.2.1"
   }

--- a/sedy/package.json
+++ b/sedy/package.json
@@ -16,10 +16,10 @@
     "config": "~1.20.1",
     "escape-string-regexp": "~1.0.5",
     "github": "~0.2.4",
-    "jsonwebtoken": "^7.3.0",
+    "jsonwebtoken": "~7.3.0",
     "oauth": "~0.9.14",
     "octonode": "~0.7.5",
-    "request": "^2.80.0"
+    "request": "~2.80.0"
   },
   "devDependencies": {
     "babel-core": "~6.7.7",

--- a/sedy/src/git/clients/github.js
+++ b/sedy/src/git/clients/github.js
@@ -1,12 +1,11 @@
 /* TODO: Split and clean this crappy file */
 
-const prReviewsPreviewHeader = 'application/vnd.github.black-cat-preview+json';
-const integrationPreviewHeader = 'application/vnd.github.machine-man-preview+json';
+const GITHUB_ACCEPT_HEADER = 'application/vnd.github.v3+json';
 
 export default (logger, github) => {
     github.requestDefaults.headers = {
         ...github.requestDefaults.headers,
-        Accept: `${prReviewsPreviewHeader}, ${integrationPreviewHeader}`,
+        Accept: GITHUB_ACCEPT_HEADER,
     };
 
     const callbackProxy = callback => (error, statusCode, response) => {

--- a/sedy/src/git/clients/github.js
+++ b/sedy/src/git/clients/github.js
@@ -1,9 +1,12 @@
 /* TODO: Split and clean this crappy file */
 
+const prReviewsPreviewHeader = 'application/vnd.github.black-cat-preview+json';
+const integrationPreviewHeader = 'application/vnd.github.machine-man-preview+json';
+
 export default (logger, github) => {
     github.requestDefaults.headers = {
         ...github.requestDefaults.headers,
-        Accept: 'application/vnd.github.black-cat-preview+json',
+        Accept: `${prReviewsPreviewHeader}, ${integrationPreviewHeader}`,
     };
 
     const callbackProxy = callback => (error, statusCode, response) => {

--- a/sedy/src/index.js
+++ b/sedy/src/index.js
@@ -11,9 +11,11 @@ import githubClientFactory from './git/clients/github';
 import loggerFactory from './lib/logger';
 import parseFactory from './parser';
 import safeguardFactory from './safeguard';
+import retrieveGithubToken from './retrieveGithubToken';
 
 const main = function* (event, context, logger, conf) {
-    const githubClient = githubClientFactory(logger, github.client(conf.bot.oauthToken));
+    const githubToken = yield retrieveGithubToken(conf.bot, event.body);
+    const githubClient = githubClientFactory(logger, github.client(githubToken));
     const parse = parseFactory(githubClient, logger);
     const parsedContent = yield parse(event);
 

--- a/sedy/src/retrieveGithubToken.js
+++ b/sedy/src/retrieveGithubToken.js
@@ -19,7 +19,7 @@ const retrieveGithubToken = function* (config, eventBody) {
         iss: config.appId,
     };
 
-    const token = jwt.sign(payload, GITHUB_APP_PRIVATE_KEY, { algorithm: 'RS256' });
+    const token = jwt.sign(payload, new Buffer(GITHUB_APP_PRIVATE_KEY, 'utf-8'), { algorithm: 'RS256' });
 
     const headers = {
         Accept: INTEGRATION_HEADER,

--- a/sedy/src/retrieveGithubToken.js
+++ b/sedy/src/retrieveGithubToken.js
@@ -1,0 +1,35 @@
+/* global GITHUB_INTEGRATION_PRIVATE_KEY */
+import jwt from 'jsonwebtoken';
+import request from 'request';
+
+const integrationPreviewHeader = 'application/vnd.github.machine-man-preview+json';
+
+const retrieveGithubToken = function* (config, eventBody) {
+    const installationId = eventBody.installation && eventBody.installation.id;
+
+    if (!installationId) {
+        return config.oauthToken;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+        iat: now,
+        exp: now + 60,
+        iss: config.integrationId,
+    };
+
+    const token = jwt.sign(payload, GITHUB_INTEGRATION_PRIVATE_KEY, { algorithm: 'RS256' });
+
+    const headers = {
+        Accept: integrationPreviewHeader,
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'Sedy-Bot',
+    };
+
+    const url = `https://api.github.com/installations/${installationId}/access_tokens`;
+    const response = yield cb => request.post(url, { headers }, (err, res) => cb(err, res));
+
+    return JSON.parse(response.body).token;
+};
+
+export default retrieveGithubToken;

--- a/sedy/src/server.js
+++ b/sedy/src/server.js
@@ -4,7 +4,7 @@ import { handler } from './';
 import githubAppPrivateKey from '../githubAppPrivateKey';
 
 // Mock webpack DefinePlugin
-global.GITHUB_APP_PRIVATE_KEY = githubAppPrivateKey;
+global.GITHUB_APP_PRIVATE_KEY = JSON.parse(githubAppPrivateKey);
 
 const port = process.env.NODE_PORT || 3000;
 http.createServer(httpServerHandler(handler)).listen(port);

--- a/sedy/src/server.js
+++ b/sedy/src/server.js
@@ -1,6 +1,10 @@
 import http from 'http';
 import httpServerHandler from './httpServerHandler';
 import { handler } from './';
+import githubIntegrationPrivateKey from '../githubIntegrationPrivateKey';
+
+// Mock webpack DefinePlugin
+global.GITHUB_INTEGRATION_PRIVATE_KEY = githubIntegrationPrivateKey;
 
 const port = process.env.NODE_PORT || 3000;
 http.createServer(httpServerHandler(handler)).listen(port);

--- a/sedy/src/server.js
+++ b/sedy/src/server.js
@@ -1,10 +1,10 @@
 import http from 'http';
 import httpServerHandler from './httpServerHandler';
 import { handler } from './';
-import githubIntegrationPrivateKey from '../githubIntegrationPrivateKey';
+import githubAppPrivateKey from '../githubAppPrivateKey';
 
 // Mock webpack DefinePlugin
-global.GITHUB_INTEGRATION_PRIVATE_KEY = githubIntegrationPrivateKey;
+global.GITHUB_APP_PRIVATE_KEY = githubAppPrivateKey;
 
 const port = process.env.NODE_PORT || 3000;
 http.createServer(httpServerHandler(handler)).listen(port);

--- a/sedy/webpack.config.babel.js
+++ b/sedy/webpack.config.babel.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import config from 'config';
 import webpack from 'webpack';
-import githubIntegrationPrivateKey from './githubIntegrationPrivateKey';
+import githubAppPrivateKey from './githubAppPrivateKey';
 
 export default {
     target: 'node',
@@ -14,7 +14,7 @@ export default {
     },
     plugins: [
         new webpack.DefinePlugin({
-            GITHUB_INTEGRATION_PRIVATE_KEY: githubIntegrationPrivateKey,
+            GITHUB_APP_PRIVATE_KEY: githubAppPrivateKey,
             config: JSON.stringify(config),
         }),
     ],

--- a/sedy/webpack.config.babel.js
+++ b/sedy/webpack.config.babel.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import config from 'config';
 import webpack from 'webpack';
+import githubIntegrationPrivateKey from './githubIntegrationPrivateKey';
 
 export default {
     target: 'node',
@@ -12,7 +13,10 @@ export default {
         libraryTarget: 'commonjs', // Ensure we have exports.handler
     },
     plugins: [
-        new webpack.DefinePlugin({ config: JSON.stringify(config) }),
+        new webpack.DefinePlugin({
+            GITHUB_INTEGRATION_PRIVATE_KEY: githubIntegrationPrivateKey,
+            config: JSON.stringify(config),
+        }),
     ],
     module: {
         // Fix a weird webpack bug


### PR DESCRIPTION
This PR aims to transform the current Sedy installation (A webhook + a Bot account) to a single GitHub Integration.

Sadly, GitHub integrations are currently in early access and the PR Reviews API too.
We need to wait for Github to fully support these features to do the change.

**EDIT:** GitHub now supports both Apps (formerly Integrations) and PR Reviews API.

## TODO
- [x] Update the code related to Integration to make it works as a GitHub App
- [x] Ensure that the lambda still works with a webhook only (but deprecate it)
- [x] Remove all early access HTTP headers