### PR TITLE
[RFR] Allow to comment from the commit list

### DIFF
--- a/sedy/src/git/objects/commits.js
+++ b/sedy/src/git/objects/commits.js
@@ -2,7 +2,7 @@ import { ValidationError } from '../errors';
 import { validate as validateObject } from '../validation';
 
 export default (client, repo, store) => {
-    const validate = commit => {
+    const validate = (commit) => {
         validateObject(commit);
 
         if (commit.type !== 'commit') {
@@ -12,7 +12,7 @@ export default (client, repo, store) => {
         return true;
     };
 
-    const standardize = commit => {
+    const standardize = (commit) => {
         validateObject(commit);
 
         return {

--- a/sedy/src/parser/parsePullRequestReview.js
+++ b/sedy/src/parser/parsePullRequestReview.js
@@ -20,7 +20,7 @@ export default (client, logger) => function* (request) {
             diffHunk: comment.diff_hunk,
             id: comment.id,
             path: comment.path,
-            position: comment.position,
+            position: comment.position || comment.original_position,
             url: comment.html_url,
         },
         commit: {

--- a/sedy/src/parser/parsePullRequestReview.spec.js
+++ b/sedy/src/parser/parsePullRequestReview.spec.js
@@ -83,7 +83,10 @@ describe('review parsing', () => {
             }]),
         };
 
-        const { fixes: [{ comment: comment1 }, { comment: comment2 }] } = yield parsePullRequestReviewFactory(client)(request);
+        const { fixes: [
+            { comment: comment1 },
+            { comment: comment2 },
+        ] } = yield parsePullRequestReviewFactory(client)(request);
 
         assert.deepEqual(comment1, {
             body: 'comment body',
@@ -104,5 +107,27 @@ describe('review parsing', () => {
             position: 'diff position',
             url: 'comment url',
         });
+    });
+
+    it('should return the `original position` if the `positon` is missing', function* () {
+        const client = {
+            getCommentsFromReviewId: () => Promise.resolve([{
+                body: 'comment body',
+                commit_id: 'commit_id',
+                created_at: 'comment date',
+                diff_hunk: 'diff hunk',
+                html_url: 'comment url',
+                id: 'comment id',
+                path: 'comment path',
+                position: null,
+                original_position: 'original position',
+                user: {
+                    login: 'Someone',
+                },
+            }]),
+        };
+
+        const { fixes: [{ comment }] } = yield parsePullRequestReviewFactory(client)(request);
+        assert.equal(comment.position, 'original position');
     });
 });


### PR DESCRIPTION
When we try a sed comment from a commit (and not from the `Files changed` tab),
and/or we write a sed comment from the deletion side of the review, the
GitHub API might not send the `position` of the diff hunk but its
`original_position`.

This PR should fix #79