### PR TITLE
Revert "[RFR] Allow to comment from the commit list"

### DIFF
--- a/sedy/src/git/objects/commits.js
+++ b/sedy/src/git/objects/commits.js
@@ -2,7 +2,7 @@ import { ValidationError } from '../errors';
 import { validate as validateObject } from '../validation';
 
 export default (client, repo, store) => {
-    const validate = (commit) => {
+    const validate = commit => {
         validateObject(commit);
 
         if (commit.type !== 'commit') {
@@ -12,7 +12,7 @@ export default (client, repo, store) => {
         return true;
     };
 
-    const standardize = (commit) => {
+    const standardize = commit => {
         validateObject(commit);
 
         return {

--- a/sedy/src/parser/parsePullRequestReview.js
+++ b/sedy/src/parser/parsePullRequestReview.js
@@ -20,7 +20,7 @@ export default (client, logger) => function* (request) {
             diffHunk: comment.diff_hunk,
             id: comment.id,
             path: comment.path,
-            position: comment.position || comment.original_position,
+            position: comment.position,
             url: comment.html_url,
         },
         commit: {

--- a/sedy/src/parser/parsePullRequestReview.spec.js
+++ b/sedy/src/parser/parsePullRequestReview.spec.js
@@ -83,10 +83,7 @@ describe('review parsing', () => {
             }]),
         };
 
-        const { fixes: [
-            { comment: comment1 },
-            { comment: comment2 },
-        ] } = yield parsePullRequestReviewFactory(client)(request);
+        const { fixes: [{ comment: comment1 }, { comment: comment2 }] } = yield parsePullRequestReviewFactory(client)(request);
 
         assert.deepEqual(comment1, {
             body: 'comment body',
@@ -107,27 +104,5 @@ describe('review parsing', () => {
             position: 'diff position',
             url: 'comment url',
         });
-    });
-
-    it('should return the `original position` if the `positon` is missing', function* () {
-        const client = {
-            getCommentsFromReviewId: () => Promise.resolve([{
-                body: 'comment body',
-                commit_id: 'commit_id',
-                created_at: 'comment date',
-                diff_hunk: 'diff hunk',
-                html_url: 'comment url',
-                id: 'comment id',
-                path: 'comment path',
-                position: null,
-                original_position: 'original position',
-                user: {
-                    login: 'Someone',
-                },
-            }]),
-        };
-
-        const { fixes: [{ comment }] } = yield parsePullRequestReviewFactory(client)(request);
-        assert.equal(comment.position, 'original position');
     });
 });


### PR DESCRIPTION
Reverts marmelab/sedy#83

`position: comment.position || comment.original_position,` is not the correct strategy.