### PR TITLE
[RFR] Restrict commit interval to 40s in order to avoid lambda timeout before push

### DIFF
--- a/sedy/config/default.json
+++ b/sedy/config/default.json
@@ -8,6 +8,7 @@
         "name": "COMMITTER-NAME",
         "email": "an@example.mail"
     },
+    "maxCommitDurationBeforePush": 40000,
     "logs": {
         "debug": false
     }

--- a/sedy/src/commiter.js
+++ b/sedy/src/commiter.js
@@ -37,5 +37,10 @@ As requested by ${parsedContent.sender} at ${fixRequest.comment.url}`;
         return false;
     };
 
-    return { init, prepareCommit, prepareFix, push };
+    return {
+        init,
+        prepareCommit,
+        prepareFix,
+        push,
+    };
 };

--- a/sedy/src/lib/logger.js
+++ b/sedy/src/lib/logger.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 
 export default config => ({
-    info: console.log,
     debug: config.logs.debug ? console.log : () => null,
+    info: console.log,
+    warn: console.warn,
     error: console.error,
 });


### PR DESCRIPTION
Occasionally, when we have a huge review with a lot of sed-comments, the API times out (at 60s of execution).

I measured that the timeout occurs after ~18 commits.

The ideal solution is to commit a chunk of fixes, and then send the rest to another lambda function that will do the rest.

But in this PR, I implemented a graceful failure: instead of trying to commit all the fixes and timeout, Sedy will push 15 fixes and stop.

NB: I didn't write tests because it's the main (untested) loop and I'll write E2E tests later instead (see https://github.com/marmelab/sedy/issues/94)